### PR TITLE
feat: screen view of alert pages

### DIFF
--- a/src/modules/alerts/AlertDetailsView.vue
+++ b/src/modules/alerts/AlertDetailsView.vue
@@ -5,38 +5,549 @@
       <h1 class="alert-details__title">Detalhes do Alerta #{{ id }}</h1>
     </div>
 
-    <div class="alert-details__content">
-      <v-card class="alert-details__card">
-        <v-card-title class="alert-details__card-title"> Informações do Alerta </v-card-title>
-        <v-card-text>
-          <p>Exibindo detalhes para o alerta com ID: {{ id }}</p>
-          <p class="text-caption">
-            Esta é uma página de exemplo. Aqui serão exibidos os detalhes completos do alerta selecionado.
-          </p>
+    <div v-if="isLoading" class="alert-details__loading">
+      <v-progress-circular indeterminate size="48" color="primary"></v-progress-circular>
+      <p>Carregando detalhes do alerta...</p>
+    </div>
+
+    <div v-else-if="error" class="alert-details__error">
+      <v-icon color="error" size="48">mdi-alert-circle</v-icon>
+      <p>{{ error }}</p>
+      <v-btn color="primary" @click="fetchAlertDetails">Tentar novamente</v-btn>
+    </div>
+
+    <div v-else-if="alertDetails" class="alert-details__content">
+      <v-card class="alert-details__info-card">
+        <v-card-title class="alert-details__card-title">
+          <v-icon class="mr-2">mdi-information</v-icon>
+          Informações do Alerta
+        </v-card-title>
+
+        <v-card-text class="alert-details__info-content">
+          <div class="alert-details__info-row">
+            <div class="alert-details__info-item">
+              <span class="alert-details__label">Indicador:</span>
+              <span class="alert-details__value alert-details__value--bold">{{ alertDetails.indicator }}</span>
+            </div>
+            <div class="alert-details__info-item">
+              <span class="alert-details__label">Status:</span>
+              <v-chip
+                :color="alertDetails.finalized ? 'success' : 'warning'"
+                size="small"
+                class="alert-details__status-chip"
+              >
+                <v-icon start size="16">
+                  {{ alertDetails.finalized ? 'mdi-check-circle' : 'mdi-clock-alert' }}
+                </v-icon>
+                {{ alertDetails.finalized ? 'Finalizado' : 'Em andamento' }}
+              </v-chip>
+            </div>
+          </div>
+
+          <div class="alert-details__info-row">
+            <div class="alert-details__info-item alert-details__info-item--full">
+              <span class="alert-details__label">Mudança de Nível:</span>
+              <div class="alert-details__level-change">
+                <v-chip
+                  :color="getLevelColor(alertDetails.previousLevel)"
+                  variant="tonal"
+                  class="alert-details__level-chip"
+                >
+                  {{ getLevelLabel(alertDetails.previousLevel) }}
+                </v-chip>
+                <v-icon>mdi-arrow-right</v-icon>
+                <v-chip
+                  :color="getLevelColor(alertDetails.currentLevel)"
+                  variant="tonal"
+                  class="alert-details__level-chip"
+                >
+                  {{ getLevelLabel(alertDetails.currentLevel) }}
+                </v-chip>
+              </div>
+            </div>
+          </div>
+
+          <div class="alert-details__info-row">
+            <div class="alert-details__info-item">
+              <span class="alert-details__label">
+                <v-icon size="18" class="mr-1">mdi-map-marker</v-icon>
+                Local:
+              </span>
+              <span class="alert-details__value">{{ alertDetails.location }}</span>
+            </div>
+            <div class="alert-details__info-item">
+              <span class="alert-details__label">
+                <v-icon size="18" class="mr-1">mdi-clock</v-icon>
+                Horário:
+              </span>
+              <span class="alert-details__value">{{ formatTimestamp(alertDetails.timestamp) }}</span>
+            </div>
+          </div>
+
+          <div class="alert-details__info-row">
+            <div class="alert-details__info-item">
+              <span class="alert-details__label">Tempo decorrido:</span>
+              <span class="alert-details__value alert-details__value--accent">{{ timeElapsed }}</span>
+            </div>
+          </div>
+
+          <div v-if="userRole === 'manager'" class="alert-details__manager-info">
+            <div class="alert-details__info-row">
+              <div class="alert-details__info-item">
+                <span class="alert-details__label">Zona:</span>
+                <span class="alert-details__value">{{ alertDetails.zone }}</span>
+              </div>
+              <div class="alert-details__info-item">
+                <span class="alert-details__label">Radar:</span>
+                <span class="alert-details__value">{{ alertDetails.radar_id }}</span>
+              </div>
+            </div>
+
+            <div v-if="alertDetails.affected_radars && alertDetails.affected_radars.length > 0" class="alert-details__affected-radars">
+              <span class="alert-details__label">Radares Afetados:</span>
+              <div class="alert-details__radar-chips">
+                <v-chip
+                  v-for="radar in alertDetails.affected_radars"
+                  :key="radar"
+                  size="small"
+                  color="error"
+                  variant="tonal"
+                  class="mr-2 mb-2"
+                >
+                  <v-icon start size="16">mdi-radar</v-icon>
+                  {{ radar }}
+                </v-chip>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="alertDetails.description" class="alert-details__description">
+            <span class="alert-details__label">Descrição:</span>
+            <p class="alert-details__description-text">{{ alertDetails.description }}</p>
+          </div>
         </v-card-text>
       </v-card>
+
+      <div v-if="userRole === 'agent' && !alertDetails.finalized" class="alert-details__agent-section">
+        <v-card class="alert-details__card mb-4">
+          <v-card-title class="alert-details__card-title">
+            <v-icon class="mr-2">mdi-clipboard-text</v-icon>
+            Orientações Iniciais
+          </v-card-title>
+          <v-card-text>
+            <v-alert type="info" variant="tonal" class="mb-0">
+              <div class="alert-details__orientation">
+                <v-icon size="24" class="mr-3">mdi-map-marker-radius</v-icon>
+                <div>
+                  <strong>Recomendação:</strong> Dirija-se ao radar <strong>{{ alertDetails.radar_id }}</strong>
+                  localizado em <strong>{{ alertDetails.location }}</strong> e identifique o problema no local.
+                </div>
+              </div>
+            </v-alert>
+          </v-card-text>
+        </v-card>
+
+        <v-card class="alert-details__card mb-4">
+          <v-card-title class="alert-details__card-title">
+            <v-icon class="mr-2">mdi-alert-box</v-icon>
+            Identificação do Problema
+          </v-card-title>
+          <v-card-text>
+            <v-select
+              v-model="selectedProblem"
+              :items="problems"
+              item-title="name"
+              item-value="id"
+              label="Selecione o problema identificado"
+              variant="outlined"
+              :hint="selectedProblemDescription"
+              persistent-hint
+              @update:model-value="onProblemSelected"
+            >
+              <template #prepend-inner>
+                <v-icon>mdi-magnify</v-icon>
+              </template>
+            </v-select>
+
+            <div v-if="problems.length === 0" class="alert-details__no-problems">
+              <v-icon color="warning" size="32">mdi-alert</v-icon>
+              <p class="mt-2">Nenhum problema cadastrado encontrado.</p>
+              <v-btn color="success" variant="tonal" class="mt-3" @click="contactManager">
+                <v-icon start>mdi-whatsapp</v-icon>
+                Contatar Gestor pelo WhatsApp
+              </v-btn>
+              <p class="text-caption mt-2">
+                Entre em contato com o gestor para solicitar a criação do problema e protocolo adequados.
+              </p>
+            </div>
+          </v-card-text>
+        </v-card>
+
+        <v-card v-if="selectedProblem" class="alert-details__card mb-4">
+          <v-card-title class="alert-details__card-title">
+            <v-icon class="mr-2">mdi-format-list-checkbox</v-icon>
+            Protocolo de Resolução
+          </v-card-title>
+          <v-card-text>
+            <div v-if="isLoadingProtocol" class="alert-details__protocol-loading">
+              <v-progress-circular indeterminate size="32" color="primary"></v-progress-circular>
+              <p>Carregando protocolo...</p>
+            </div>
+
+            <div v-else-if="protocol" class="alert-details__protocol">
+              <h3 class="alert-details__protocol-title">{{ protocol.title }}</h3>
+              <v-list class="alert-details__protocol-steps">
+                <v-list-item
+                  v-for="(step, index) in protocol.steps"
+                  :key="index"
+                  class="alert-details__protocol-step"
+                >
+                  <template #prepend>
+                    <v-avatar color="primary" size="32" class="mr-3">
+                      <span class="text-white">{{ index + 1 }}</span>
+                    </v-avatar>
+                  </template>
+                  <v-list-item-title>{{ step }}</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </div>
+
+            <v-alert v-else type="warning" variant="tonal">
+              <div class="alert-details__no-protocol">
+                <v-icon size="24" class="mr-3">mdi-alert-circle</v-icon>
+                <div>
+                  <strong>Protocolo não encontrado</strong>
+                  <p class="mt-1">O protocolo para este problema ainda não foi criado.</p>
+                  <v-btn color="success" variant="text" class="mt-2 pa-0" @click="contactManager">
+                    <v-icon start>mdi-whatsapp</v-icon>
+                    Contatar Gestor
+                  </v-btn>
+                </div>
+              </div>
+            </v-alert>
+          </v-card-text>
+        </v-card>
+
+        <v-card v-if="protocol" class="alert-details__card mb-4">
+          <v-card-title class="alert-details__card-title">
+            <v-icon class="mr-2">mdi-note-text</v-icon>
+            Anotações da Resolução
+          </v-card-title>
+          <v-card-text>
+            <v-textarea
+              v-model="resolutionNotes"
+              label="Descreva como o problema foi resolvido"
+              variant="outlined"
+              rows="4"
+              placeholder="Ex: Acidente removido, via liberada às 14:30. Sem feridos."
+            ></v-textarea>
+          </v-card-text>
+        </v-card>
+
+        <div class="alert-details__actions">
+          <v-btn
+            color="success"
+            size="large"
+            :disabled="!canFinalize"
+            @click="finalizeAlert"
+            block
+          >
+            <v-icon start>mdi-check-circle</v-icon>
+            Finalizar Alerta
+          </v-btn>
+          <p v-if="!canFinalize" class="text-caption text-center mt-2 text-grey">
+            Complete todos os passos acima para finalizar o alerta
+          </p>
+        </div>
+      </div>
+
+      <div v-if="userRole === 'manager' && !alertDetails.finalized" class="alert-details__manager-section">
+        <v-card class="alert-details__card">
+          <v-card-title class="alert-details__card-title">
+            <v-icon class="mr-2">mdi-account-tie</v-icon>
+            Acionar Agente
+          </v-card-title>
+          <v-card-text>
+            <v-select
+              v-model="selectedAgent"
+              :items="availableAgents"
+              item-title="name"
+              item-value="id"
+              label="Selecione o agente para resolver este alerta"
+              variant="outlined"
+            >
+              <template #prepend-inner>
+                <v-icon>mdi-account-search</v-icon>
+              </template>
+              <template #item="{ props: itemProps }">
+                <v-list-item v-bind="itemProps">
+                  <template #prepend>
+                    <v-avatar color="primary" size="32">
+                      <v-icon>mdi-account</v-icon>
+                    </v-avatar>
+                  </template>
+                  <template #append>
+                    <v-chip size="x-small" color="success" variant="tonal">
+                      Disponível
+                    </v-chip>
+                  </template>
+                </v-list-item>
+              </template>
+            </v-select>
+
+            <div v-if="availableAgents.length === 0" class="alert-details__no-agents">
+              <v-icon color="warning" size="32">mdi-alert</v-icon>
+              <p class="mt-2">Nenhum agente disponível no momento.</p>
+            </div>
+          </v-card-text>
+        </v-card>
+
+        <div class="alert-details__actions mt-4">
+          <v-btn
+            color="success"
+            size="large"
+            :disabled="!canFinalize"
+            @click="contactAgent"
+            block
+          >
+            <v-icon start>mdi-whatsapp</v-icon>
+            Contatar Agente pelo WhatsApp
+          </v-btn>
+        </div>
+      </div>
+
+      <v-alert v-if="alertDetails.finalized" type="success" variant="tonal" class="mt-4">
+        <v-icon start size="24">mdi-check-circle</v-icon>
+        <strong>Este alerta já foi finalizado</strong>
+      </v-alert>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
+import alertServices from '@/modules/alerts/services/alertServices'
+import type { AlertDetails, Problem, Protocol, Agent } from '@/modules/alerts/types/alertsTypes'
+import { LEVELS_ENUM } from '@/shared/enums'
 
 interface Props {
   id: string
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
 const router = useRouter()
+
+const alertDetails = ref<AlertDetails | null>(null)
+const problems = ref<Problem[]>([])
+const agents = ref<Agent[]>([])
+const selectedProblem = ref<number | null>(null)
+const protocol = ref<Protocol | null>(null)
+const selectedAgent = ref<number | null>(null)
+const resolutionNotes = ref('')
+
+const isLoading = ref(true)
+const isLoadingProtocol = ref(false)
+const error = ref<string | null>(null)
+
+let updateInterval: number | null = null
+
+const userRole = ref<'agent' | 'manager'>('agent')
+
+const levelColors: Record<number, string> = {
+  1: 'success',
+  2: 'success',
+  3: 'warning',
+  4: 'error',
+  5: 'error',
+}
+
+const getLevelLabel = (level: number): string => {
+  return LEVELS_ENUM[level as keyof typeof LEVELS_ENUM] || 'Desconhecido'
+}
+
+const getLevelColor = (level: number): string => {
+  return levelColors[level] || 'grey'
+}
+
+const formatTimestamp = (timestamp: string): string => {
+  const date = new Date(timestamp)
+  return date.toLocaleString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+const timeElapsed = computed(() => {
+  if (!alertDetails.value) return ''
+
+  const now = new Date()
+  const alertTime = new Date(alertDetails.value.timestamp)
+  const diffMs = now.getTime() - alertTime.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+
+  if (diffMins < 1) return 'Agora mesmo'
+  if (diffMins < 60) return `${diffMins} minutos atrás`
+
+  const diffHours = Math.floor(diffMins / 60)
+  if (diffHours < 24) return `${diffHours} horas atrás`
+
+  const diffDays = Math.floor(diffHours / 24)
+  return `${diffDays} dias atrás`
+})
+
+const selectedProblemDescription = computed(() => {
+  if (!selectedProblem.value) return ''
+  const problem = problems.value.find(p => p.id === selectedProblem.value)
+  return problem?.description || ''
+})
+
+const availableAgents = computed(() => {
+  return agents.value.filter(agent => agent.available)
+})
+
+const canFinalize = computed(() => {
+  if (userRole.value === 'agent') {
+    return selectedProblem.value !== null && protocol.value !== null && resolutionNotes.value.trim() !== ''
+  }
+  return selectedAgent.value !== null
+})
+
+const managerContactPhone = '5512999999999'
+
+const fetchAlertDetails = async () => {
+  try {
+    isLoading.value = true
+    error.value = null
+
+    const alertId = Number(props.id)
+    const response = await alertServices.getDetails(alertId)
+    alertDetails.value = response.data
+  } catch (err) {
+    error.value = 'Erro ao carregar detalhes do alerta'
+    console.error('Erro ao buscar detalhes do alerta:', err)
+  } finally {
+    isLoading.value = false
+  }
+}
+
+const fetchProblems = async () => {
+  try {
+    const response = await alertServices.getProblems()
+    problems.value = response.data.items
+  } catch (err) {
+    console.error('Erro ao buscar problemas:', err)
+  }
+}
+
+const fetchAgents = async () => {
+  try {
+    const response = await alertServices.getAgents()
+    agents.value = response.data.items
+  } catch (err) {
+    console.error('Erro ao buscar agentes:', err)
+  }
+}
+
+const onProblemSelected = async (problemId: number) => {
+  if (!problemId) {
+    protocol.value = null
+    return
+  }
+
+  selectedProblem.value = problemId
+  protocol.value = null
+
+  try {
+    isLoadingProtocol.value = true
+    const response = await alertServices.getProtocol(problemId)
+    protocol.value = response.data
+  } catch (err) {
+    console.error('Erro ao buscar protocolo:', err)
+    protocol.value = null
+  } finally {
+    isLoadingProtocol.value = false
+  }
+}
+
+const contactManager = () => {
+  const message = encodeURIComponent(
+    `Olá! Não encontrei o problema adequado para o alerta #${alertDetails.value?.alert_id}. ` +
+    `Indicador: ${alertDetails.value?.indicator}. ` +
+    `Local: ${alertDetails.value?.location}. ` +
+    `Preciso que crie o problema e protocolo necessário.`
+  )
+  window.open(`https://wa.me/${managerContactPhone}?text=${message}`, '_blank')
+}
+
+const contactAgent = () => {
+  const agent = agents.value.find(a => a.id === selectedAgent.value)
+  if (!agent) return
+
+  const message = encodeURIComponent(
+    `Olá ${agent.name}! Você foi acionado para resolver o alerta #${alertDetails.value?.alert_id}. ` +
+    `Indicador: ${alertDetails.value?.indicator}. ` +
+    `Local: ${alertDetails.value?.location}. ` +
+    `Zona: ${alertDetails.value?.zone}. ` +
+    `Por favor, dirija-se ao local para avaliação.`
+  )
+  window.open(`https://wa.me/${agent.phone}?text=${message}`, '_blank')
+}
+
+const finalizeAlert = async () => {
+  if (!canFinalize.value || !alertDetails.value) return
+
+  try {
+    const data = userRole.value === 'agent' ? {
+      problem_id: selectedProblem.value ?? undefined,
+      notes: resolutionNotes.value,
+    } : {
+      agent_id: selectedAgent.value ?? undefined,
+    }
+
+    await alertServices.finalizeAlert(alertDetails.value.alert_id, data)
+
+    alert('Alerta finalizado com sucesso!')
+    router.push({ name: 'alerts' })
+  } catch (err) {
+    error.value = 'Erro ao finalizar alerta'
+    console.error('Erro ao finalizar alerta:', err)
+  }
+}
 
 const goBack = () => {
   router.go(-1)
 }
+
+onMounted(async () => {
+  await fetchAlertDetails()
+
+  if (userRole.value === 'agent') {
+    await fetchProblems()
+  } else {
+    await fetchAgents()
+  }
+
+  updateInterval = window.setInterval(() => {
+    fetchAlertDetails()
+  }, 60000)
+})
+
+onUnmounted(() => {
+  if (updateInterval) {
+    clearInterval(updateInterval)
+  }
+})
 </script>
 
 <style lang="scss" scoped>
 .alert-details {
   padding: 24px;
+  max-width: 1200px;
+  margin: 0 auto;
 
   &__header {
     display: flex;
@@ -50,25 +561,192 @@ const goBack = () => {
   }
 
   &__title {
-    font-size: 1.5rem;
+    font-size: 1.75rem;
     font-weight: 600;
     color: #1f2937;
     margin: 0;
   }
 
+  &__loading,
+  &__error {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    padding: 64px 24px;
+    text-align: center;
+    color: #6b7280;
+  }
+
   &__content {
-    max-width: 800px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
   }
 
   &__card {
     border-radius: 12px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08) !important;
+    border: 1px solid #e5e7eb;
   }
 
   &__card-title {
     background: #f8f9fa;
-    border-bottom: 1px solid #e0e0e0;
+    border-bottom: 1px solid #e5e7eb;
     font-weight: 600;
+    font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    padding: 16px 20px;
+  }
+
+  &__info-content {
+    padding: 24px;
+  }
+
+  &__info-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+    margin-bottom: 20px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__info-item {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    &--full {
+      grid-column: 1 / -1;
+    }
+  }
+
+  &__label {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #6b7280;
+    display: flex;
+    align-items: center;
+  }
+
+  &__value {
+    font-size: 1rem;
+    color: #1f2937;
+
+    &--bold {
+      font-weight: 600;
+      font-size: 1.1rem;
+    }
+
+    &--accent {
+      color: #2563eb;
+      font-weight: 500;
+    }
+  }
+
+  &__level-change {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  &__level-chip {
+    font-weight: 500;
+  }
+
+  &__status-chip {
+    font-weight: 500;
+  }
+
+  &__manager-info {
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 2px solid #e5e7eb;
+  }
+
+  &__affected-radars {
+    margin-top: 16px;
+  }
+
+  &__radar-chips {
+    margin-top: 8px;
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  &__description {
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 2px solid #e5e7eb;
+  }
+
+  &__description-text {
+    margin-top: 8px;
+    color: #4b5563;
+    line-height: 1.6;
+  }
+
+  &__orientation {
+    display: flex;
+    align-items: flex-start;
+  }
+
+  &__no-problems,
+  &__no-agents {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 32px 16px;
+    text-align: center;
+    color: #6b7280;
+  }
+
+  &__protocol-loading {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 24px;
+    justify-content: center;
+  }
+
+  &__protocol-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 16px;
+  }
+
+  &__protocol-steps {
+    background: transparent;
+    padding: 0;
+  }
+
+  &__protocol-step {
+    padding: 12px 0;
+    border-bottom: 1px solid #f3f4f6;
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &__no-protocol {
+    display: flex;
+    align-items: flex-start;
+  }
+
+  &__actions {
+    margin-top: 24px;
+  }
+
+  &__agent-section,
+  &__manager-section {
+    margin-top: 24px;
   }
 }
 </style>

--- a/src/modules/alerts/mock/routes/alertRoutes.ts
+++ b/src/modules/alerts/mock/routes/alertRoutes.ts
@@ -1,6 +1,12 @@
 import { APIFailureWrapper, mockFlag } from '@/utils/mockUtils.ts'
 
+interface MockParams {
+  id?: string
+  problemId?: string
+}
+
 const alertsRoutes = [
+  // Lista dos últimos 10 alertas
   mockFlag(
     {
       method: 'get',
@@ -112,6 +118,270 @@ const alertsRoutes = [
         return APIFailureWrapper({
           content: { items: response, total: response.length },
           errorMessage: 'Erro ao listar últimos 10 alertas',
+        })
+      },
+    },
+    'on',
+  ),
+
+  // Detalhes de um alerta específico
+  mockFlag(
+    {
+      method: 'get',
+      url: '/alerts/:id/details',
+      result: (params: MockParams) => {
+        const alertId = Number(params.id)
+
+        const mockAlerts: Record<number, {
+          id: number
+          alert_id: number
+          indicator: string
+          currentLevel: number
+          previousLevel: number
+          location: string
+          timestamp: string
+          finalized: boolean
+          radar_id: string
+          zone: string
+          description: string
+          affected_radars: string[]
+        }> = {
+          101: {
+            id: 1,
+            alert_id: 101,
+            indicator: 'Congestionamento',
+            currentLevel: 4,
+            previousLevel: 2,
+            location: 'Av. Paraibuna, 1234',
+            timestamp: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+            finalized: false,
+            radar_id: 'RADAR-001',
+            zone: 'Zona Leste',
+            description: 'Congestionamento detectado com aumento significativo no fluxo de veículos',
+            affected_radars: ['RADAR-001', 'RADAR-002', 'RADAR-003'],
+          },
+          102: {
+            id: 2,
+            alert_id: 102,
+            indicator: 'Densidade de Veículos',
+            currentLevel: 3,
+            previousLevel: 1,
+            location: "R. Dr. Nelson D'Ávila, 567",
+            timestamp: new Date(Date.now() - 8 * 60 * 1000).toISOString(),
+            finalized: false,
+            radar_id: 'RADAR-005',
+            zone: 'Zona Central',
+            description: 'Aumento na densidade de veículos acima do esperado para o horário',
+            affected_radars: ['RADAR-005', 'RADAR-006'],
+          },
+          103: {
+            id: 3,
+            alert_id: 103,
+            indicator: 'Infrações de Velocidade',
+            currentLevel: 5,
+            previousLevel: 3,
+            location: 'Av. Florestan Fernandes, 890',
+            timestamp: new Date(Date.now() - 18 * 60 * 1000).toISOString(),
+            finalized: true,
+            radar_id: 'RADAR-010',
+            zone: 'Zona Sul',
+            description: 'Múltiplas infrações de velocidade detectadas',
+            affected_radars: ['RADAR-010'],
+          },
+        }
+
+        const response = mockAlerts[alertId] || {
+          id: alertId,
+          alert_id: alertId,
+          indicator: 'Alerta Genérico',
+          currentLevel: 3,
+          previousLevel: 2,
+          location: 'Localização não especificada',
+          timestamp: new Date().toISOString(),
+          finalized: false,
+          radar_id: 'RADAR-000',
+          zone: 'Zona Desconhecida',
+          description: 'Detalhes do alerta não disponíveis',
+          affected_radars: ['RADAR-000'],
+        }
+
+        return APIFailureWrapper({
+          content: response,
+          errorMessage: 'Erro ao buscar detalhes do alerta',
+        })
+      },
+    },
+    'on',
+  ),
+
+  // Lista de problemas
+  mockFlag(
+    {
+      method: 'get',
+      url: '/problems',
+      result: () => {
+        const response = [
+          { id: 1, name: 'Acidente', description: 'Colisão entre veículos' },
+          { id: 2, name: 'Veículo quebrado', description: 'Veículo parado na via' },
+          { id: 3, name: 'Obra na via', description: 'Manutenção ou construção' },
+          { id: 4, name: 'Manifestação', description: 'Protesto ou evento' },
+          { id: 5, name: 'Alagamento', description: 'Via alagada' },
+          { id: 6, name: 'Semáforo com defeito', description: 'Sinalização não funcionando' },
+        ]
+
+        return APIFailureWrapper({
+          content: { items: response },
+          errorMessage: 'Erro ao listar problemas',
+        })
+      },
+    },
+    'on',
+  ),
+
+  // Protocolos por problema
+  mockFlag(
+    {
+      method: 'get',
+      url: '/protocols/:problemId',
+      result: (params: MockParams) => {
+        const protocols: Record<number, {
+          id: number
+          problem_id: number
+          title: string
+          steps: string[]
+        }> = {
+          1: {
+            id: 1,
+            problem_id: 1,
+            title: 'Protocolo para Acidentes',
+            steps: [
+              'Isolar a área do acidente com cones e faixas de segurança',
+              'Acionar SAMU se houver feridos graves',
+              'Fotografar a cena e coletar informações dos envolvidos',
+              'Acionar guincho para remoção dos veículos',
+              'Registrar ocorrência no sistema com todas as informações coletadas',
+              'Liberar a via após remoção completa dos veículos',
+              'Notificar o gestor sobre a conclusão',
+            ],
+          },
+          2: {
+            id: 2,
+            problem_id: 2,
+            title: 'Protocolo para Veículo Quebrado',
+            steps: [
+              'Contatar o motorista do veículo',
+              'Solicitar que sinalize o veículo com triângulo',
+              'Acionar guincho para remoção',
+              'Orientar sobre estacionamento irregular se aplicável',
+              'Aguardar remoção do veículo',
+              'Confirmar liberação da via',
+            ],
+          },
+          3: {
+            id: 3,
+            problem_id: 3,
+            title: 'Protocolo para Obras na Via',
+            steps: [
+              'Verificar se há autorização para a obra',
+              'Conferir sinalização adequada no local',
+              'Solicitar ajustes na sinalização se necessário',
+              'Registrar no sistema as informações da obra',
+              'Monitorar impacto no tráfego',
+              'Manter contato com responsável pela obra',
+            ],
+          },
+          4: {
+            id: 4,
+            problem_id: 4,
+            title: 'Protocolo para Manifestação',
+            steps: [
+              'Avaliar o tamanho e impacto da manifestação',
+              'Acionar Polícia Militar se necessário',
+              'Estabelecer rotas alternativas',
+              'Comunicar aos órgãos competentes',
+              'Monitorar evolução da situação',
+              'Registrar informações detalhadas no sistema',
+            ],
+          },
+          5: {
+            id: 5,
+            problem_id: 5,
+            title: 'Protocolo para Alagamento',
+            steps: [
+              'Isolar a área alagada',
+              'Acionar Defesa Civil',
+              'Estabelecer rotas alternativas',
+              'Alertar motoristas sobre o perigo',
+              'Acompanhar drenagem da água',
+              'Liberar via somente após segurança confirmada',
+            ],
+          },
+          6: {
+            id: 6,
+            problem_id: 6,
+            title: 'Protocolo para Semáforo com Defeito',
+            steps: [
+              'Identificar o tipo de defeito no semáforo',
+              'Acionar equipe de manutenção',
+              'Avaliar necessidade de agentes de trânsito no local',
+              'Informar aos motoristas sobre o problema',
+              'Aguardar reparo',
+              'Confirmar funcionamento após manutenção',
+            ],
+          },
+        }
+
+        const problemId = Number(params.problemId)
+        const protocol = protocols[problemId]
+
+        return APIFailureWrapper({
+          content: protocol || null,
+          errorMessage: 'Erro ao buscar protocolo',
+        })
+      },
+    },
+    'on',
+  ),
+
+  // Lista de agentes
+  mockFlag(
+    {
+      method: 'get',
+      url: '/agents',
+      result: () => {
+        const response = [
+          { id: 1, name: 'João Silva', phone: '5512991234567', available: true },
+          { id: 2, name: 'Maria Santos', phone: '5512992345678', available: true },
+          { id: 3, name: 'Pedro Costa', phone: '5512993456789', available: false },
+          { id: 4, name: 'Ana Oliveira', phone: '5512994567890', available: true },
+          { id: 5, name: 'Carlos Souza', phone: '5512995678901', available: true },
+          { id: 6, name: 'Juliana Lima', phone: '5512996789012', available: false },
+        ]
+
+        return APIFailureWrapper({
+          content: { items: response },
+          errorMessage: 'Erro ao listar agentes',
+        })
+      },
+    },
+    'on',
+  ),
+
+  // Finalizar alerta
+  mockFlag(
+    {
+      method: 'post',
+      url: '/alerts/:id/finalize',
+      result: (params: MockParams, body: unknown) => {
+        console.log('Finalizando alerta:', params.id, body)
+
+        return APIFailureWrapper({
+          content: {
+            success: true,
+            message: 'Alerta finalizado com sucesso',
+            alert_id: params.id,
+          },
+          errorMessage: 'Erro ao finalizar alerta',
         })
       },
     },

--- a/src/modules/alerts/services/alertServices.ts
+++ b/src/modules/alerts/services/alertServices.ts
@@ -1,8 +1,42 @@
 import api from '@/utils/servicesUtils.ts'
-import type { LastTenAlertsResponse } from '@/modules/alerts/types/alertsTypes.ts'
+import type {
+  LastTenAlertsResponse,
+  AlertDetails,
+  Problem,
+  Protocol,
+  Agent
+} from '@/modules/alerts/types/alertsTypes.ts'
+
+interface FinalizeAlertPayload {
+  problem_id?: number
+  notes?: string
+  agent_id?: number
+}
+
+interface FinalizeAlertResponse {
+  success: boolean
+  message: string
+  alert_id: number
+}
 
 const alerts = {
-  getLastTen: (): Promise<{ data: LastTenAlertsResponse }> => api.get('/alerts/last-ten'),
+  getLastTen: (): Promise<{ data: LastTenAlertsResponse }> =>
+    api.get('/alerts/last-ten'),
+
+  getDetails: (id: number): Promise<{ data: AlertDetails }> =>
+    api.get(`/alerts/${id}/details`),
+
+  getProblems: (): Promise<{ data: { items: Problem[] } }> =>
+    api.get('/problems'),
+
+  getProtocol: (problemId: number): Promise<{ data: Protocol | null }> =>
+    api.get(`/protocols/${problemId}`),
+
+  getAgents: (): Promise<{ data: { items: Agent[] } }> =>
+    api.get('/agents'),
+
+  finalizeAlert: (id: number, data?: FinalizeAlertPayload): Promise<{ data: FinalizeAlertResponse }> =>
+    api.post(`/alerts/${id}/finalize`, data),
 }
 
 export default alerts

--- a/src/modules/alerts/types/alertsTypes.ts
+++ b/src/modules/alerts/types/alertsTypes.ts
@@ -1,3 +1,5 @@
+// ADICIONE estes tipos ao seu arquivo existente
+
 export interface Alert {
   id: number
   alert_id: number
@@ -12,4 +14,39 @@ export interface Alert {
 export interface LastTenAlertsResponse {
   items: Alert[]
   total: number
+}
+
+export interface AlertDetails {
+  id: number
+  alert_id: number
+  indicator: string
+  currentLevel: number
+  previousLevel: number
+  location: string
+  timestamp: string
+  finalized: boolean
+  radar_id?: string
+  zone?: string
+  description?: string
+  affected_radars?: string[]
+}
+
+export interface Problem {
+  id: number
+  name: string
+  description: string
+}
+
+export interface Protocol {
+  id: number
+  problem_id: number
+  title: string
+  steps: string[]
+}
+
+export interface Agent {
+  id: number
+  name: string
+  phone: string
+  available: boolean
 }


### PR DESCRIPTION
Este PR foi criado com a intenção de:

Exibir os detalhes completos de um alerta, permitindo que o agente e o gestor visualizem informações, problemas, protocolos e ações disponíveis.

Regras de negócio

Exibe dados como indicador, status, local e horário.

O agente pode identificar o problema, seguir o protocolo e finalizar o alerta.

O gestor pode acionar agentes disponíveis via WhatsApp.

Atualização automática dos detalhes a cada 1 minuto.

Como testar

Subir o projeto localmente com npm run mock.

Acessar a página de detalhes de um alerta.

Testar as ações conforme o papel (agente ou gestor).