### PR TITLE
Feat: Add logic filter for zones and date

### DIFF
--- a/src/modules/home/HomeView.vue
+++ b/src/modules/home/HomeView.vue
@@ -1,5 +1,5 @@
-<script lang="ts" setup>
-import { ref, onMounted } from 'vue'
+<script lang="ts" setup> 
+import { ref, onMounted, computed, watch } from 'vue'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import sjcGeojson from '@/utils/sjcGeojson.json'
@@ -7,12 +7,81 @@ import sjcGeojson from '@/utils/sjcGeojson.json'
 const mapContainer = ref<HTMLDivElement | null>(null)
 const map = ref<L.Map | null>(null)
 const geoJsonLayer = ref<L.GeoJSON<any> | null>(null)
-const selectedZones = ref<string[]>([])
-const filteredZones = ref<string[]>([])
-const startDateTime = ref<string>('')
-const endDateTime = ref<string>('')
+
+/* =========================
+   VARIÁVEIS DE ZONAS
+   ========================= */
+const selectedZones = ref<string[]>([])       // ⬅️ pré-seleção (duplo clique)
+const zonasSelecionadasLista = selectedZones  // alias reativo
+const filteredZones = ref<string[]>([])       // ⬅️ zonas aplicadas (as “salvas”)
+
+/* =========================
+   VARIÁVEIS DO PERÍODO (INPUTS)
+   ========================= */
+// Recebem o valor do <v-date-input> (string | Date | null)
+const startDateTime = ref<string | Date | null>(null)
+const endDateTime   = ref<string | Date | null>(null)
+
+/* =========================
+   VARIÁVEIS FINAIS DO FILTRO (USO NA LÓGICA)
+   ========================= */
+// Só recebem valor se EXISTE data inicial; se não houver, ficam null
+const filtroDataHoraInicial = ref<string | null>(null)  // ⬅️ valor “salvo”
+const filtroDataHoraFinal   = ref<string | null>(null)  // ⬅️ valor “salvo”
+
+// Mantém as variáveis finais sincronizadas (normaliza Date -> string ISO)
+// Regra: se houver INÍCIO e FIM vazio, usa AGORA como FIM.
+watch([startDateTime, endDateTime], ([ini, fim]) => {
+  const normalize = (v: unknown): string | null => {
+    if (v == null || v === '') return null
+    if (v instanceof Date && !isNaN(v.getTime())) return v.toISOString()
+    if (typeof v === 'string' && v.trim() !== '') return v
+    return null
+  }
+
+  const nIni = normalize(ini)
+  let nFim = normalize(fim)
+
+  if (nIni) {
+    if (!nFim) nFim = new Date().toISOString() // fim padrão = agora
+    filtroDataHoraInicial.value = nIni
+    filtroDataHoraFinal.value   = nFim
+  } else {
+    filtroDataHoraInicial.value = null
+    filtroDataHoraFinal.value   = null
+  }
+})
 
 const activeAnimations = new Map<string, any>()
+
+// (mantido para usos internos; calcula {id,nome} da PRÉ-seleção)
+const zonasSelecionadasDetalhes = computed(() => {
+  const selectedSet = new Set(selectedZones.value)
+  const seen = new Set<string>()
+  const tmp: Array<{ id: string | number | null; nome: string }> = []
+
+  const features = (sjcGeojson as any).features as any[]
+  for (const f of features) {
+    const p = f?.properties || {}
+    if (p?.layer === 'zona' && selectedSet.has(p.regiao) && !seen.has(p.regiao)) {
+      const id =
+        f?.id ??
+        p?.id ??
+        p?.codigo ??
+        p?.cod ??
+        p?.idZona ??
+        p?.ID ??
+        null
+      tmp.push({ id, nome: p.regiao })
+      seen.add(p.regiao)
+    }
+  }
+
+  const byName = new Map(tmp.map(t => [t.nome, t]))
+  return selectedZones.value
+    .map(nome => byName.get(nome))
+    .filter(Boolean) as Array<{ id: string | number | null; nome: string }>
+})
 
 onMounted(() => {
   if (!mapContainer.value) return
@@ -24,7 +93,7 @@ onMounted(() => {
     attribution: '&copy; <a href="https://www.openstreetmap.org/">OSM</a> contributors',
   }).addTo(map.value)
 
-  drawMap(sjcGeojson.features)
+  drawMap((sjcGeojson as any).features)
 })
 
 function drawMap(features: any[]) {
@@ -94,7 +163,7 @@ function toggleZone(region: string, layer: L.Layer) {
     selectedZones.value.push(region)
     startAnimation(region, layer)
   }
-  drawMap(sjcGeojson.features)
+  drawMap((sjcGeojson as any).features)
 }
 
 function startAnimation(region: string, layer: L.Layer) {
@@ -124,15 +193,15 @@ function stopAnimation(region: string) {
 }
 
 function applyFilter() {
-  let filtered = sjcGeojson.features
+  let filtered = (sjcGeojson as any).features
   if (selectedZones.value.length > 0) {
-    filtered = sjcGeojson.features.filter((f: any) => {
+    filtered = (sjcGeojson as any).features.filter((f: any) => {
       if (f.properties?.layer === 'municipio') return true
       return selectedZones.value.includes(f.properties?.regiao)
     })
   }
 
-  filteredZones.value = [...selectedZones.value]
+  filteredZones.value = [...selectedZones.value] // ⬅️ aqui “salva” as zonas aplicadas
   selectedZones.value = []
 
   drawMap(filtered)
@@ -143,11 +212,11 @@ function applyFilter() {
 function clearSelection() {
   selectedZones.value = []
   filteredZones.value = []
-  startDateTime.value = ''
-  endDateTime.value = ''
+  startDateTime.value = '' // pode ser '' ou null
+  endDateTime.value   = ''
   activeAnimations.forEach(clearInterval)
   activeAnimations.clear()
-  drawMap(sjcGeojson.features)
+  drawMap((sjcGeojson as any).features)
 }
 </script>
 
@@ -194,6 +263,7 @@ function clearSelection() {
     <div class="instructions">ℹ️ Dê <b>dois cliques</b> em uma zona para selecioná-la antes de aplicar o filtro.</div>
 
     <div ref="mapContainer" class="map"></div>
+    <!-- Quadrado de debug removido -->
   </div>
 </template>
 

--- a/src/modules/home/HomeView.vue
+++ b/src/modules/home/HomeView.vue
@@ -9,83 +9,87 @@ const map = ref<L.Map | null>(null)
 const geoJsonLayer = ref<L.GeoJSON<any> | null>(null)
 
 /* =========================
-   VARIÁVEIS DE ZONAS
+   ZONAS
    ========================= */
-const selectedZones = ref<string[]>([])       // ⬅️ pré-seleção (duplo clique)
+const selectedZones = ref<string[]>([])       // pré-seleção (duplo clique)
 const zonasSelecionadasLista = selectedZones  // alias reativo
-const filteredZones = ref<string[]>([])       // ⬅️ zonas aplicadas (as “salvas”)
+const filteredZones = ref<string[]>([])       // zonas aplicadas (as “salvas”)
+
+/* Todas as zonas do GeoJSON (usado quando nada for selecionado) */
+const ALL_ZONES: string[] = (() => {
+  const set = new Set<string>()
+  const features = (sjcGeojson as any).features as any[]
+  for (const f of features) {
+    const p = f?.properties || {}
+    if (p?.layer === 'zona' && typeof p?.regiao === 'string') set.add(p.regiao)
+  }
+  return Array.from(set)
+})()
 
 /* =========================
-   VARIÁVEIS DO PERÍODO (INPUTS)
+   DATAS
    ========================= */
 // Recebem o valor do <v-date-input> (string | Date | null)
 const startDateTime = ref<string | Date | null>(null)
 const endDateTime   = ref<string | Date | null>(null)
 
-/* =========================
-   VARIÁVEIS FINAIS DO FILTRO (USO NA LÓGICA)
-   ========================= */
-// Só recebem valor se EXISTE data inicial; se não houver, ficam null
-const filtroDataHoraInicial = ref<string | null>(null)  // ⬅️ valor “salvo”
-const filtroDataHoraFinal   = ref<string | null>(null)  // ⬅️ valor “salvo”
+// Variáveis finais do filtro (salvas)
+const filtroDataHoraInicial = ref<string | null>(null)
+const filtroDataHoraFinal   = ref<string | null>(null)
 
-// Mantém as variáveis finais sincronizadas (normaliza Date -> string ISO)
-// Regra: se houver INÍCIO e FIM vazio, usa AGORA como FIM.
+// Normalizador auxiliar
+const normalize = (v: unknown): string | null => {
+  if (v == null || v === '') return null
+  if (v instanceof Date && !isNaN(v.getTime())) return v.toISOString()
+  if (typeof v === 'string' && v.trim() !== '') return v
+  return null
+}
+
+/* Regras pedidas:
+   - sem início e sem fim -> ambos null
+   - só início -> fim = agora
+   - só fim -> início = null, fim = informado
+   - ambos -> ambos informados
+*/
 watch([startDateTime, endDateTime], ([ini, fim]) => {
-  const normalize = (v: unknown): string | null => {
-    if (v == null || v === '') return null
-    if (v instanceof Date && !isNaN(v.getTime())) return v.toISOString()
-    if (typeof v === 'string' && v.trim() !== '') return v
-    return null
-  }
-
   const nIni = normalize(ini)
-  let nFim = normalize(fim)
+  const nFim = normalize(fim)
 
-  if (nIni) {
-    if (!nFim) nFim = new Date().toISOString() // fim padrão = agora
-    filtroDataHoraInicial.value = nIni
-    filtroDataHoraFinal.value   = nFim
-  } else {
+  if (!nIni && !nFim) {
     filtroDataHoraInicial.value = null
     filtroDataHoraFinal.value   = null
+  } else if (nIni && !nFim) {
+    filtroDataHoraInicial.value = nIni
+    filtroDataHoraFinal.value   = new Date().toISOString()
+  } else if (!nIni && nFim) {
+    filtroDataHoraInicial.value = null
+    filtroDataHoraFinal.value   = nFim
+  } else {
+    filtroDataHoraInicial.value = nIni!
+    filtroDataHoraFinal.value   = nFim!
   }
 })
 
+/* Habilitar o botão "Filtrar" quando:
+   - ambas nulas
+   - início com valor e fim nulo
+   - ambas com valor
+   (=> desabilita quando só o fim tem valor)
+*/
+const isEmpty = (v: unknown) => v == null || (typeof v === 'string' && v.trim() === '')
+const canFilter = computed(() => {
+  const hasStart = !isEmpty(startDateTime.value)
+  const hasEnd   = !isEmpty(endDateTime.value)
+  return (!hasStart && !hasEnd) || (hasStart && !hasEnd) || (hasStart && hasEnd)
+})
+
+/* =========================
+   MAPA
+   ========================= */
 const activeAnimations = new Map<string, any>()
-
-// (mantido para usos internos; calcula {id,nome} da PRÉ-seleção)
-const zonasSelecionadasDetalhes = computed(() => {
-  const selectedSet = new Set(selectedZones.value)
-  const seen = new Set<string>()
-  const tmp: Array<{ id: string | number | null; nome: string }> = []
-
-  const features = (sjcGeojson as any).features as any[]
-  for (const f of features) {
-    const p = f?.properties || {}
-    if (p?.layer === 'zona' && selectedSet.has(p.regiao) && !seen.has(p.regiao)) {
-      const id =
-        f?.id ??
-        p?.id ??
-        p?.codigo ??
-        p?.cod ??
-        p?.idZona ??
-        p?.ID ??
-        null
-      tmp.push({ id, nome: p.regiao })
-      seen.add(p.regiao)
-    }
-  }
-
-  const byName = new Map(tmp.map(t => [t.nome, t]))
-  return selectedZones.value
-    .map(nome => byName.get(nome))
-    .filter(Boolean) as Array<{ id: string | number | null; nome: string }>
-})
 
 onMounted(() => {
   if (!mapContainer.value) return
-
   map.value = L.map(mapContainer.value).setView([-23.2, -45.9], 11)
 
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -98,10 +102,7 @@ onMounted(() => {
 
 function drawMap(features: any[]) {
   if (!map.value) return
-
-  if (geoJsonLayer.value) {
-    map.value.removeLayer(geoJsonLayer.value)
-  }
+  if (geoJsonLayer.value) map.value.removeLayer(geoJsonLayer.value)
 
   geoJsonLayer.value = L.geoJSON(features, {
     style: (feature) => {
@@ -112,25 +113,18 @@ function drawMap(features: any[]) {
 
       let borderColor = '#333'
       let fillColor = props.color || '#3388ff'
-
-      if (selected) {
-        borderColor = '#0044ff'
-        fillColor = '#3399ff'
-      } else if (filtered) {
-        borderColor = '#008000'
-        fillColor = '#33cc33'
-      }
+      if (selected) { borderColor = '#0044ff'; fillColor = '#3399ff' }
+      else if (filtered) { borderColor = '#008000'; fillColor = '#33cc33' }
 
       return {
         color: borderColor,
         weight: selected || filtered ? 3 : 1,
-        fillColor: fillColor,
+        fillColor,
         fillOpacity: props.layer === 'municipio' ? 0.2 : 0.6,
       }
     },
     onEachFeature: (feature, layer) => {
       const props = feature?.properties || {}
-
       if (props.layer === 'zona') {
         layer.bindTooltip(`Zona ${props.regiao}`, { sticky: true })
         layer.bindPopup(`
@@ -142,7 +136,6 @@ function drawMap(features: any[]) {
           Pessoas (est. 2025): ${props.pessoasEst || 'N/D'}<br>
           Moradores/dom. (est. 2025): ${props.moradoresEst || 'N/D'}
         `)
-
         layer.on('dblclick', (e) => {
           L.DomEvent.stopPropagation(e)
           toggleZone(props.regiao, layer)
@@ -169,7 +162,6 @@ function toggleZone(region: string, layer: L.Layer) {
 function startAnimation(region: string, layer: L.Layer) {
   stopAnimation(region)
   if (!(layer as any).setStyle) return
-
   let glow = 0
   const interval = setInterval(() => {
     if (!(layer as any).setStyle) return
@@ -193,17 +185,20 @@ function stopAnimation(region: string) {
 }
 
 function applyFilter() {
+  const nothingSelected = selectedZones.value.length === 0
+
   let filtered = (sjcGeojson as any).features
-  if (selectedZones.value.length > 0) {
+  if (!nothingSelected) {
     filtered = (sjcGeojson as any).features.filter((f: any) => {
       if (f.properties?.layer === 'municipio') return true
       return selectedZones.value.includes(f.properties?.regiao)
     })
+    filteredZones.value = [...selectedZones.value]       // aplica só as escolhidas
+  } else {
+    filteredZones.value = [...ALL_ZONES]                 // aplica TODAS as zonas
   }
 
-  filteredZones.value = [...selectedZones.value] // ⬅️ aqui “salva” as zonas aplicadas
-  selectedZones.value = []
-
+  selectedZones.value = [] // limpa a pré-seleção
   drawMap(filtered)
   activeAnimations.forEach(clearInterval)
   activeAnimations.clear()
@@ -229,7 +224,7 @@ function clearSelection() {
             v-model="startDateTime"
             label="Data/hora inicial"
             placeholder="Selecione data e hora"
-          ></v-date-input>
+          />
         </div>
 
         <div class="filter-group">
@@ -237,7 +232,7 @@ function clearSelection() {
             v-model="endDateTime"
             label="Data/hora final"
             placeholder="Selecione data e hora"
-          ></v-date-input>
+          />
         </div>
       </div>
 
@@ -248,7 +243,7 @@ function clearSelection() {
       </div>
 
       <div class="buttons">
-        <button @click="applyFilter" :disabled="!selectedZones.length && !startDateTime && !endDateTime">
+        <button @click="applyFilter" :disabled="!canFilter">
           Filtrar
         </button>
         <button
@@ -263,7 +258,6 @@ function clearSelection() {
     <div class="instructions">ℹ️ Dê <b>dois cliques</b> em uma zona para selecioná-la antes de aplicar o filtro.</div>
 
     <div ref="mapContainer" class="map"></div>
-    <!-- Quadrado de debug removido -->
   </div>
 </template>
 
@@ -293,11 +287,6 @@ function clearSelection() {
         flex-direction: column;
         font-size: 0.85rem;
         width: 220px;
-
-        label {
-          font-weight: 500;
-          margin-bottom: 0.2rem;
-        }
 
         :deep(.v-date-input) {
           width: 100%;
@@ -329,21 +318,8 @@ function clearSelection() {
           cursor: not-allowed;
         }
 
-        &:first-child {
-          background: #16a34a;
-
-          &:hover:not(:disabled) {
-            background: #15803d;
-          }
-        }
-
-        &:last-child {
-          background: #dc2626;
-
-          &:hover:not(:disabled) {
-            background: #b91c1c;
-          }
-        }
+        &:first-child { background: #16a34a; }
+        &:last-child  { background: #dc2626; }
       }
     }
   }


### PR DESCRIPTION
Pré-seleção de zonas (selectedZones): o usuário dá duplo clique no mapa para adicionar/remover zonas nesse rascunho.

Zonas aplicadas/salvas (filteredZones): só muda quando você clica Filtrar.

Se nada estiver pré-selecionado: aplica todas as zonas (usa ALL_ZONES).

Se houver pré-seleção: aplica somente as escolhidas.

Datas (startDateTime e endDateTime nos inputs → filtroDataHoraInicial e filtroDataHoraFinal salvos):

Sem início e sem fim → ambos null.

Só início → fim = agora (ISO).

Só fim → início = null, fim = informado.

Ambos → salva ambos normalizados (string ISO quando for Date).

Habilitação do botão “Filtrar” (canFilter):

Habilita se: ambas nulas OU só início OU ambas.

Desabilita se: só fim.