### PR TITLE
fix: set region levels by color - endpoint

### DIFF
--- a/src/modules/home/mock/routes/mapRoutes.ts
+++ b/src/modules/home/mock/routes/mapRoutes.ts
@@ -6,7 +6,7 @@ const sjcGeoJsonRoutes = [
   mockFlag(
     {
       method: 'get',
-      url: '/alert/per-region',
+      url: '/alerts/per-region',
       result: () => {
         return APIFailureWrapper({
           content: {

--- a/src/modules/home/services/mapService.ts
+++ b/src/modules/home/services/mapService.ts
@@ -1,6 +1,6 @@
-import axios from 'axios'
+import api from '@/utils/servicesUtils'
 
 export async function getRegionsLevel() {
-  const response = await axios.get('/alert/per-region')
+  const response = await api.get('/alerts/per-region')
   return response.data
 }


### PR DESCRIPTION
## Descrição do PR
O PR tem por fim ajutstar o endpoint para exibir as cores dos níveis de cada região no mapa. Esses níveis são a média calculada, baseada em todos indicadores
[Card](https://denariusdata2024.atlassian.net/jira/software/projects/RAD/boards/1?selectedIssue=RAD-101)

## Regras de negócio
- Ao entrar na tela, e juntamente com as notificações, será recarregado os níveis

## Como testar  
1. Entrar no front e visualizar se está correspondente