### PR TITLE
feat: visual for manager to associate zone

### DIFF
--- a/src/modules/alerts/components/NotificationDropdown.vue
+++ b/src/modules/alerts/components/NotificationDropdown.vue
@@ -5,13 +5,19 @@ import type { Alert } from '@/modules/alerts/types/alertsTypes'
 import { LEVELS_ENUM } from '@/shared/enums'
 import { useRouter } from 'vue-router'
 import { registerPeriodicTask } from '@/shared/periodicUpdater'
+import { useRoleStore } from '@/modules/login/store/roleStore'
 
 const router = useRouter()
+const roleStore = useRoleStore()
 
 const isOpen = ref(false)
 const alerts = ref<Alert[]>([])
 const isLoading = ref(false)
 const error = ref<string | null>(null)
+
+const isAuthorized = computed(
+  () => roleStore.isAuthenticated && (roleStore.isAgente || roleStore.isGestor || roleStore.isAdmin),
+)
 
 const alertsCount = computed(() =>
   alerts.value.reduce((count, alert) => {
@@ -28,6 +34,11 @@ const levelColors = {
 }
 
 const fetchAlerts = async () => {
+  if (!isAuthorized.value) {
+    alerts.value = []
+    return
+  }
+
   try {
     isLoading.value = true
     error.value = null
@@ -67,8 +78,10 @@ const goToAlertsPage = () => {
 let unregisterNotificationTask: (() => void) | null = null
 
 onMounted(async () => {
-  await fetchAlerts()
-  unregisterNotificationTask = registerPeriodicTask(fetchAlerts)
+  if (isAuthorized.value) {
+    await fetchAlerts()
+    unregisterNotificationTask = registerPeriodicTask(fetchAlerts)
+  }
 })
 
 onUnmounted(() => {

--- a/src/modules/home/HomeView.vue
+++ b/src/modules/home/HomeView.vue
@@ -38,7 +38,7 @@ const regionsLevelData = ref<{ region_id: number; level: number }[]>([])
 
 let unregisterPeriodicTask: (() => void) | null = null
 
-const isAgent = computed(() => roleStore.getRoles().value.includes('ROLE_AGENTE'))
+const isAgent = computed(() => roleStore.isAgente)
 
 const criteriaForTable = computed<Criterion[]>(() => {
   const uniqueCriteria = new Map()

--- a/src/modules/login/service/loginServices.ts
+++ b/src/modules/login/service/loginServices.ts
@@ -1,5 +1,5 @@
 import api from '@/utils/servicesUtils.ts'
-import { UserRole } from '../store/roleStore'
+import { UserRole } from '@/modules/users/enum/roles'
 
 interface LoginResponse {
   token: string

--- a/src/modules/persons/pages/PersonsView.vue
+++ b/src/modules/persons/pages/PersonsView.vue
@@ -104,6 +104,7 @@ onMounted(loadData);
             <th>Nome</th>
             <th>Email</th>
             <th>Perfil</th>
+            <th>Região</th> 
             <th class="actions-col">Ações</th>
           </tr>
         </thead>
@@ -113,7 +114,12 @@ onMounted(loadData);
             <td>{{ p.name }}</td>
             <td>{{ p.email }}</td>
             <td>{{ p.role }}</td>
-
+            <td>
+              <span v-for="(r, i) in p.regions" :key="r.id">
+                {{ r.name }}<span v-if="i < p.regions.length - 1">, </span>
+              </span>
+            </td> 
+            
             <td class="actions">
               <v-icon class="edit-icon" title="Editar" @click="openEditModal(p)">
                 mdi-pencil
@@ -128,17 +134,27 @@ onMounted(loadData);
       </table>
     </div>
 
-<AddPagination
-  :page="page"
-  :total-pages="totalPages"
-  @go-first="goToFirst"
-  @go-prev="previousPage"
-  @go-next="nextPage"
-  @go-last="goToLast"
-/>
+    <AddPagination
+      :page="page"
+      :total-pages="totalPages"
+      @go-first="goToFirst"
+      @go-prev="previousPage"
+      @go-next="nextPage"
+      @go-last="goToLast"
+    />
 
-    <AddEditPersonModal v-model="showAddEditModal" :is-edit="isEdit" :person="editingPerson" @saved="handleSaved" />
-    <PersonDeleteModal v-model="showDeleteModal" :user-id="userToDelete" @confirm="handleConfirmDelete" />
+    <AddEditPersonModal
+      v-model="showAddEditModal"
+      :is-edit="isEdit"
+      :person="editingPerson"
+      @saved="handleSaved"
+    />
+
+    <PersonDeleteModal
+      v-model="showDeleteModal"
+      :user-id="userToDelete"
+      @confirm="handleConfirmDelete"
+    />
   </div>
 </template>
 
@@ -207,5 +223,4 @@ onMounted(loadData);
   color: #d32f2f;
   transform: scale(1.1);
 }
-
 </style>

--- a/src/shared/AutoCompleteMenu.vue
+++ b/src/shared/AutoCompleteMenu.vue
@@ -34,7 +34,6 @@ const allMenuItems: MenuItem[] = [
   { title: 'Indicadores', value: 'indicators', route: 'indicators' },
   { title: 'Protocolos', value: 'protocols', route: 'protocols', requiresAuth: true, requiresGestor: true },
   { title: 'Usuários', value: 'persons', route: 'persons', requiresAuth: true, requiresAdmin: true },
-  { title: 'Controle de Agente', value: 'persons', route: 'persons', requiresAuth: true, requiresGestor: true },
 ]
 
 const menuItems = computed(() => {

--- a/src/shared/AutoCompleteMenu.vue
+++ b/src/shared/AutoCompleteMenu.vue
@@ -27,6 +27,7 @@ const menuItems: MenuItem[] = [
   { title: 'Dashboards', value: 'dashboards', route: 'dashboards' },
   { title: 'Indicadores', value: 'indicators', route: 'indicators' },
   { title: 'Protocolos', value: 'protocols', route: 'protocols' },
+  { title: 'Controle de Agente', value: 'persons', route: 'persons' }
 ]
 
 const menu = computed({


### PR DESCRIPTION
Descrição do PR

Este PR adiciona o visual para o gestor associar as zonas dos agentes:

É possível cadastrar, editar e excluir qualquer agente.

Precisa do Backend para conseguir visualizar a tela.

[Card](https://denariusdata2024.atlassian.net/browse/RAD-47?atlOrigin=eyJpIjoiZjJlZTgwMDhkOGE2NGZhM2I2YTUzM2E3MjBmYjJiMzAiLCJwIjoiaiJ9) 

<img width="1781" height="510" alt="image" src="https://github.com/user-attachments/assets/e1de8c4f-416a-4f2e-8fea-0d5dc318ce09" />
